### PR TITLE
Laravel 予定一覧取得API連携

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,16 +2,17 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Routes, RouterModule } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
+import { TodoCardComponent } from './components/todo/todo-card/todo-card.component';
 import { HomeComponent } from './pages/home/home.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 import { TodoListComponent } from './pages/todo/todo-list/todo-list.component';
 import { TodoAddComponent } from './pages/todo/todo-add/todo-add.component';
-import { TodoCardComponent } from './components/todo/todo-card/todo-card.component';
 
 // ルーティング設定
 const routes: Routes = [
@@ -43,6 +44,7 @@ const routes: Routes = [
     FormsModule,
     RouterModule.forRoot(routes),
     ReactiveFormsModule,
+    HttpClientModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/pages/todo/todo-list/todo-list.component.ts
+++ b/src/app/pages/todo/todo-list/todo-list.component.ts
@@ -13,7 +13,10 @@ export class TodoListComponent implements OnInit {
   constructor(private todoService: TodoService) {}
 
   ngOnInit(): void {
-    this.todoList = this.todoService.getList();
+    this.todoService.getList().subscribe((data) => {
+      this.todoList = data;
+    });
+    // this.todoList = this.todoService.getList();
   }
 
   // ステータス変更

--- a/src/app/services/todo/todo.service.ts
+++ b/src/app/services/todo/todo.service.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Todo } from './todo';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TodoService {
+  private apiUrl = 'http://localhost:8000/api/todos';
   todoList: Todo[] = [];
 
-  constructor() {}
+  constructor(private http: HttpClient) {}
 
   /**
    * 新規登録
@@ -33,8 +36,9 @@ export class TodoService {
   /**
    * 全件取得
    */
-  getList(): Todo[] {
-    return this.todoList.sort((a, b) => (a.startDate > b.startDate ? 1 : -1));
+  getList(): Observable<any> {
+    // return this.todoList.sort((a, b) => (a.startDate > b.startDate ? 1 : -1));
+    return this.http.get(this.apiUrl);
   }
 
   /**


### PR DESCRIPTION
# この PR の目的

Laravel 予定一覧取得API連携

# やったこと

 - バックエンド側(Laravel)側で用意したAPI(予定一覧取得API)連携組込

# やってないこと

- 登録、削除、編集のAPI組込

# 確認事項

動作確認をする際にフロント側、バックエンド側両方のプロジェクトを立ち上げる

# 備考


